### PR TITLE
Update macro parsing of complex expressions

### DIFF
--- a/server/src/parsers/grammars/hpp.pegjs
+++ b/server/src/parsers/grammars/hpp.pegjs
@@ -57,10 +57,22 @@ NormalDeclaration
   }
   
 VariableValue
-  = num:NumericalExpression { return num } 
+  = num:NumericalExpression { return num }
+  / macro:MacroValue { return macro }
   / str:StringLiteral { return str }
   / trans:TranslationIdentifier { return trans }
-  / macro:Identifier { return { macro: macro } }
+
+MacroValue
+  = macro:Identifier __ "(" __ params:MacroParams __ ")" { 
+    return "MACRO{" + macro + "("+ params + ")" + "}"
+  }
+  
+MacroParams
+  = head:VariableValue tail:(__ "," __ val:VariableValue {return val})* { 
+    if(tail.length)
+	    return head + "," + tail.join(",")
+    return head
+  }
 
 ArrayVariableValue
   = VariableValue 
@@ -85,6 +97,7 @@ NumericalValue "number"
   = "(" __ exp:NumericalExpression __ ")" { return "(" + exp + ")" }
   / prefix:"0x" value:[0-9A-Fa-f]+ { return prefix + value.join("") }
   / prefix:[+-]? vals:Digit+ tail:("." suffix:Digit*)? supertail:("e" NumericalValue)? { return vals.join("") }
+  / MacroValue
   / Identifier
   
 ArrayDeclaration


### PR DESCRIPTION
While I was developing one of the displays for rewrite of KP Liberation I've been using a lot of Macros in it.

I've noticed that my dialog was breaking the parser due to usage of said macros.

Example usage:
```sqf
class KPLIB_DialogTitle: KP_DialogTitleC {
            text = "$STR_BUILD";
            w = KP_GETWPLAIN(KP_WIDTH_BUILD,1); // This breaks the parser
        };
```

Offending file:
[KPLIB_buildDisplay.hpp.txt](https://github.com/SkaceKamen/vscode-sqflint/files/2267795/KPLIB_buildDisplay.hpp.txt)

I've updated the parser grammar to be compatible with this macro syntax. Due to being able to use macro functions in conjuction with arithmetic operators I decided to serialize macro instead of making it into an object in parser output. (Output is: `MACRO{<macroName>(<param1>,<paramN>)}`)

Macro like this:
```sqf
KP_GETWPLAIN(KP_WIDTH_BUILD,1)
```

Will be serialized to:
```
"MACRO{KP_GETWPLAIN(KP_WIDTH_BUILD,1)}"
```

This is not ideal so if you think it could be implemented in a better way feel free to change it.

I've tested the compiled grammar in VS Code and it seemed to work fine in quite big [project](https://github.com/KillahPotatoes/KP-Liberation/tree/v0.97).
