### PR TITLE
Added support for "includePrefixes" to HPP parser

### DIFF
--- a/server/src/modules/ext.ts
+++ b/server/src/modules/ext.ts
@@ -283,6 +283,7 @@ export class ExtModule extends Module {
             fs.readFile(filename, () => {
                 try {
                     this.log(`Proccessing: ${filename}`);
+                    Hpp.setPaths(this.getSettings().includePrefixes)
                     this.process(Hpp.parse(filename), filename);
                     this.log(`Proccessed: ${filename}`);
 

--- a/server/src/modules/mission.ts
+++ b/server/src/modules/mission.ts
@@ -120,6 +120,7 @@ export class MissionModule extends Module {
         return new Promise<void>((resolve) => {
             fs.readFile(filename, () => {
                 try {
+                    Hpp.setPaths(this.getSettings().includePrefixes)
                     this.process(Hpp.parse(filename), filename);
                 } catch(error) {
                     // Skip errors, probably binarized mission


### PR DESCRIPTION
HPP parser now uses `includePrefixes` when searching for included files. This should fix #45