### PR TITLE
Support for += and -= in hpp files

### DIFF
--- a/server/src/parsers/grammars/hpp.pegjs
+++ b/server/src/parsers/grammars/hpp.pegjs
@@ -115,12 +115,12 @@ NumericalValue "number"
   / prefix:[+-]? "." suffix:Digit* supertail:("e" NumericalValue)? { return '0.' + suffix.join("") }
   / MacroValue
   / Identifier
-  
+
 Sqf "sqf"
   = head:Identifier tail:(__ Identifier __)* { return head + " " + tail.map((t) => t[1]).join(" ") }
 
 ArrayDeclaration
-  = name:Identifier __ "[]" __ "=" __ value:ArrayValues EOS {
+  = name:Identifier __ "[]" __ ("+")? __ "=" __ value:ArrayValues EOS {
     return {
     	"variable": name,
         "value": value

--- a/server/src/parsers/grammars/hpp.pegjs
+++ b/server/src/parsers/grammars/hpp.pegjs
@@ -120,7 +120,7 @@ Sqf "sqf"
   = head:Identifier tail:(__ Identifier __)* { return head + " " + tail.map((t) => t[1]).join(" ") }
 
 ArrayDeclaration
-  = name:Identifier __ "[]" __ ("+")? __ "=" __ value:ArrayValues EOS {
+  = name:Identifier __ "[]" __ ("+"/"-")? __ "=" __ value:ArrayValues EOS {
     return {
     	"variable": name,
         "value": value


### PR DESCRIPTION
As requested in #85, HPP files included in `description.ext` should now accept `+=` and `-=`.