### PR TITLE
Add support for multiline strings delimeted by "\n"

### DIFF
--- a/server/src/parsers/grammars/hpp.pegjs
+++ b/server/src/parsers/grammars/hpp.pegjs
@@ -60,6 +60,7 @@ NormalDeclaration
 VariableValue
   = num:NumericalExpression { return num }
   / macro:MacroValue { return macro }
+  / str:MultiLineStringLiteral { return str }
   / str:StringLiteral { return str }
   / trans:TranslationIdentifier { return trans }
 
@@ -211,6 +212,13 @@ SingleLineComment
 
 StringLiteral "string"
   = "\"" chars:("\"\"" / [^"\""])* "\"" { return chars.join("") }
+
+MultiLineStringLiteral "multiline string"
+  = lines:(StringLiteral (" \\n " StringLiteral)* ) {
+      return lines[1].reduce(function(result, element) {
+    	return result + "\n" + element[1]
+      }, lines[0])
+    }
 
 DoubleStringCharacter
   = "\"" "\""


### PR DESCRIPTION
Used for example in mission.sqm if you have multiple lines in `init` field:
```cpp
class Attributes
{
	init="this animate [""mainturret"", rad 45, true]; " \n "this animate [""maingun"", rad -7, true]; ";
};
```