### PR TITLE
Add extension setting to toggle undefined variable warning for global variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,12 @@
 					"default": true,
 					"description": "Process and display sqflint warnings."
 				},
+				"sqflint.globalVarWarnings": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show 'Possibly undefined variable' warnings for global variables. (NOTE! Restart your Visual Studio Code after changing this setting!)"
+				}
+				,
 				"sqflint.indexWorkspace": {
 					"type": "boolean",
 					"default": true,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -60,6 +60,7 @@ interface Settings {
  */
 export interface SQFLintSettings {
     warnings: boolean;
+    globalVarWarnings: boolean,
     indexWorkspace: boolean;
     indexWorkspaceTwice: boolean;
     checkPaths: boolean;
@@ -252,6 +253,7 @@ export class SQFLintServer {
 
         this.settings = {
             warnings: true,
+            globalVarWarnings: false,
             indexWorkspace: true,
             indexWorkspaceTwice: true,
             exclude: [],
@@ -277,6 +279,7 @@ export class SQFLintServer {
         this.settings.indexWorkspace = settings.sqflint.indexWorkspace;
         this.settings.indexWorkspaceTwice = settings.sqflint.indexWorkspaceTwice;
         this.settings.warnings = settings.sqflint.warnings;
+        this.settings.globalVarWarnings = settings.sqflint.globalVarWarnings;
         this.settings.exclude = settings.sqflint.exclude;
         this.settings.ignoredVariables = settings.sqflint.ignoredVariables;
         this.settings.includePrefixes = settings.sqflint.includePrefixes;
@@ -802,7 +805,7 @@ export class SQFLintServer {
                                     }
 
                                     // Add warning if global variable wasn't defined.
-                                    if (!defined && this.settings.warnings && !this.ignoredVariablesSet[item.ident]) {
+                                    if (!defined && this.settings.warnings && !this.ignoredVariablesSet[item.ident] && this.settings.globalVarWarnings) {
                                         for (const u in item.usage) {
                                             diagnostics.push({
                                                 severity: DiagnosticSeverity.Warning,


### PR DESCRIPTION
Added an extension setting to toggle undefined global variable warnings on and off, as sometimes the 'Possibly undefined variable' warning for global variables with its underlining clutters the code and VS Code 'Problems' list.

The default setting is 'false', i.e. "don't show undefined global variable warnings" as this is most likely the preferred one for most developers.