### PR TITLE
Fix ext parser slowing down the whole plugin

### DIFF
--- a/server/src/modules/ext.ts
+++ b/server/src/modules/ext.ts
@@ -22,7 +22,7 @@ interface Documentation {
 }
 
 export class ExtModule extends Module {
-    private single: SingleRunner = new SingleRunner(200);
+    private single: SingleRunner = new SingleRunner(20);
 
     public functions: { [descriptionFile: string]: { [functionName: string]: Function } } = {};
     private documentation: { [variable: string]: Documentation } = {};
@@ -120,10 +120,15 @@ export class ExtModule extends Module {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public parseDocument(textDocument: TextDocument, linter?: SQFLint): Promise<void> {
+        const uri = Uri.parse(textDocument.uri);
+
+        if (path.basename(uri.fsPath) != "description.ext" && path.extname(uri.fsPath) != ".hpp") {
+            return Promise.resolve();
+        }
+
         return new Promise<void>((resolve) => {
             this.single.run(() => {
                 // @TODO: Rewrite this, the logic can be much simpler
-                const uri = Uri.parse(textDocument.uri);
                 if (path.basename(uri.fsPath) == "description.ext") {
                     resolve(this.parseFile(uri.fsPath));
                 } else if (path.extname(uri.fsPath) == ".hpp") {


### PR DESCRIPTION
The "SingleRunner" is simple debounce. Due to the way everything is implemented, this caused every parse to take at least 200ms for no reason.

Decrease the timeout to 20ms and only trigger the ext parser when `description.ext` or `*.hpp` is modified.